### PR TITLE
Shell : Calculate the Total Number and Size of Files by Extension in All Subdirectories

### DIFF
--- a/GithubStatistics/README.md
+++ b/GithubStatistics/README.md
@@ -1,4 +1,4 @@
-# [Github Statistics](/README.md#※-github-statistics)
+# [Github Statistics](/README.md#-github-statistics)
 
 Manufacture *Github* user statistics by its REST API and crawling
 

--- a/GithubStatistics/README.md
+++ b/GithubStatistics/README.md
@@ -5,7 +5,7 @@ Manufacture *Github* user statistics by its REST API and crawling
 
 ### \<List>
 
-- [Shell : Calculate the Total Number and Size of Files by Extension in All Subfolders (2024.03.19)](#shell--calculate-the-total-number-and-size-of-files-by-extension-in-all-subfolders-20240319)
+- [Shell : Calculate the Total Number and Size of Files by Extension in All Subdirectories (2024.03.19)](#shell--calculate-the-total-number-and-size-of-files-by-extension-in-all-subdirectories-20240319)
 - [Python : Get Daily Contribution Data by Crawling (2023.12.31)](#python--get-daily-contribution-data-by-crawling-20231231)
 - [TypeScript : List a User's Repositories (2023.10.26)](#typescript--list-a-users-repositories-20231026)
 - [Google Sheet : Most Used Languages (2023.10.25)](#google-sheet--most-used-languages-20231025)
@@ -13,7 +13,7 @@ Manufacture *Github* user statistics by its REST API and crawling
 
 
 
-## [Shell : Calculate the Total Number and Size of Files by Extension in All Subfolders (2024.03.19)](#list)
+## [Shell : Calculate the Total Number and Size of Files by Extension in All Subdirectories (2024.03.19)](#list)
 
 - Implement in 4 scripting languages: Bash, Batchfile, VBScript, PowerShell
 - Future Improvements
@@ -54,7 +54,7 @@ Manufacture *Github* user statistics by its REST API and crawling
     :: Temporary file
     set "temp_file=%TEMP%\temp.txt"
 
-    :: Get list of files and their sizes in subfolders only
+    :: Get list of files and their sizes in subdirectories only
     for /r "%search_dir%" %%F in (*) do (
         if not "%%~dpF"=="%search_dir%" (
             echo %%~zF %%~xF >> "%temp_file%"

--- a/GithubStatistics/README.md
+++ b/GithubStatistics/README.md
@@ -18,7 +18,7 @@ Manufacture *Github* user statistics by its REST API and crawling
 - Implement in 4 scripting languages: Bash, Batchfile, VBScript, PowerShell
 - Future Improvements
   - Calculate the summation
-  - Sort by the Total Size
+  - Sort by the total size
 - Code and Results
   - `CalcTotalSizeByExtension.sh`
     <details>

--- a/GithubStatistics/README.md
+++ b/GithubStatistics/README.md
@@ -5,10 +5,185 @@ Manufacture *Github* user statistics by its REST API and crawling
 
 ### \<List>
 
+- [Shell : Calculate the Total Number and Size of Files by Extension in All Subfolders (2024.03.19)](#shell--calculate-the-total-number-and-size-of-files-by-extension-in-all-subfolders-20240319)
 - [Python : Get Daily Contribution Data by Crawling (2023.12.31)](#python--get-daily-contribution-data-by-crawling-20231231)
 - [TypeScript : List a User's Repositories (2023.10.26)](#typescript--list-a-users-repositories-20231026)
 - [Google Sheet : Most Used Languages (2023.10.25)](#google-sheet--most-used-languages-20231025)
 - [Google Sheet : Dashboard Outline (2020.04.19)](#google-sheet--dashboard-outline-20200419)
+
+
+
+## [Shell : Calculate the Total Number and Size of Files by Extension in All Subfolders (2024.03.19)](#list)
+
+- Implement in 4 scripting languages: Bash, Batchfile, VBScript, PowerShell
+- Future Improvements
+  - Calculate the summation
+  - Sort by the Total Size
+- Code and Results
+  - `CalcTotalSizeByExtension.sh`
+    <details>
+      <summary>Code</summary>
+
+    ```sh
+    find */ -type f | awk -F'.' '{print $NF}' | sort | uniq -c | while read count ext; do 
+      size=$(find */ -type f -name "*.$ext" -exec du -b {} + | awk '{total+=$1} END {print total}')
+      echo "$ext $count $size"
+    done
+    ```
+    </details>
+    <details open="">
+      <summary>Console Output</summary>
+
+      ```sh
+      ini 1 345
+      json 1 102
+      txt 2 88
+      ```
+    </details>
+  - `CalcTotalSizeByExtension.bat`
+    <details>
+      <summary>Code</summary>
+
+    ```bat
+    @echo off
+    setlocal enabledelayedexpansion
+
+    :: Set the directory to search
+    set "search_dir=%~dp0"
+
+    :: Temporary file
+    set "temp_file=%TEMP%\temp.txt"
+
+    :: Get list of files and their sizes in subfolders only
+    for /r "%search_dir%" %%F in (*) do (
+        if not "%%~dpF"=="%search_dir%" (
+            echo %%~zF %%~xF >> "%temp_file%"
+        )
+    )
+
+    :: Initialize the last extension variable
+    set "lastext="
+
+    :: Process each file extension
+    for /f "tokens=1,* delims= " %%A in ('type "%temp_file%" ^| sort /+41') do (
+        set "size=%%A"
+        set "ext=%%B"
+        set "count=1"
+        if not "!lastext!"=="!ext!" (
+            if not "!lastext!"=="" (
+                :: Remove the leading dot from the extension
+                set "lastext=!lastext:~1!"
+                echo !lastext! !count! !totalsize!
+            )
+            set "totalsize=0"
+            set "count=0"
+            set "lastext=!ext!"
+        )
+        set /a totalsize+=size
+        set /a count+=1
+    )
+
+    :: Write the last extension
+    if not "!lastext!"=="" (
+        :: Remove the leading dot from the extension
+        set "lastext=!lastext:~1!"
+        echo !lastext! !count! !totalsize!
+    )
+
+    :: Clean up
+    if exist "%temp_file%" del "%temp_file%"
+
+    endlocal
+    ```
+    </details>
+    <details open="">
+      <summary>Console Output</summary>
+
+      ```bat
+      json  1 102
+      ini  1 345
+      txt  2 88
+      ```
+    </details>
+  - `CalcTotalSizeByExtension.vbs`
+    <details>
+      <summary>Code</summary>
+
+    ```vbs
+    Set dict = CreateObject("Scripting.Dictionary")
+
+    Set fso = CreateObject("Scripting.FileSystemObject")
+    Set folder = fso.GetFolder(".")
+    Set subFolders = CreateObject("Scripting.Dictionary")
+
+    ' Skip the current folder by starting with its subfolders
+    For Each subfolder in folder.SubFolders
+        subFolders.Add subfolder.Path, subfolder
+    Next
+
+    Do While subFolders.Count > 0
+        Set folder = subFolders.Item(subFolders.Keys()(0))
+        subFolders.Remove folder.Path
+        For Each subfolder in folder.SubFolders
+            subFolders.Add subfolder.Path, subfolder
+        Next
+        For Each file In folder.Files
+            ext = fso.GetExtensionName(file)
+            If Not dict.Exists(ext) Then
+                dict.Add ext, Array(0,0)
+            End If
+            fileInfo = dict(ext)
+            fileInfo(0) = fileInfo(0) + 1
+            fileInfo(1) = fileInfo(1) + file.Size
+            dict(ext) = fileInfo
+        Next
+    Loop
+
+    ' Output results to the console
+    For Each ext In dict.Keys
+        WScript.StdOut.WriteLine ext & " " & dict(ext)(0) & " " & dict(ext)(1)
+    Next
+    ```
+    </details>
+    <details open="">
+      <summary>Run & Console Output</summary>
+
+      ```vbs
+      cscript CalcTotalSizeByExtension.vbs
+      ```
+      ```vbs
+      Microsoft (R) Windows Script Host 버전 5.812
+      Copyright (C) Microsoft Corporation. All rights reserved.
+
+      json 1 102
+      ini 1 345
+      txt 2 88
+      ```
+    </details>
+  - `CalcTotalSizeByExtension.ps1`
+    <details>
+      <summary>Code</summary>
+
+    ```ps1
+    Get-ChildItem -Path . -Recurse -File | Where-Object { $_.DirectoryName -ne (Get-Location).Path } | Group-Object Extension | 
+    Select-Object @{Name='Extension';Expression={$_.Name -replace '^\.', ''}}, 
+                  @{Name='FileCount';Expression={$_.Count}}, 
+                  @{Name='TotalSize (Bytes)';Expression={$_.Group | Measure-Object -Property Length -Sum | Select-Object -ExpandProperty Sum}} | 
+    Sort-Object 'TotalSize (Bytes)' -Descending | 
+    Format-Table -AutoSize
+    ```
+    </details>
+    <details open="">
+      <summary>Console Output</summary>
+
+      ```ps1
+      Extension FileCount TotalSize (Bytes)
+      --------- --------- -----------------
+      ini               1               345
+      json              1               102
+      txt               2                88
+      ```
+    </details>
 
 
 ## [Python : Get Daily Contribution Data by Crawling (2023.12.31)](#list)
@@ -29,7 +204,7 @@ Manufacture *Github* user statistics by its REST API and crawling
       contributions_data = retrieve_daily_contributions(username=USERNAME, year={year})
       ……
   ```
-- Codes and Results
+- Code and Results
   <details>
     <summary>get_github_daily_contributions.py</summary>
 
@@ -165,7 +340,7 @@ Manufacture *Github* user statistics by its REST API and crawling
   ```bash
   node GetGithubUserStats.js {username}
   ```
-- Codes and Results
+- Code and Results
   <details>
     <summary>GetGithubUserStats.ts</summary>
 

--- a/GithubStatistics/Shell/CalcTotalSizeByExtension.bat
+++ b/GithubStatistics/Shell/CalcTotalSizeByExtension.bat
@@ -1,0 +1,53 @@
+:: Calculate the Total Number and Size of Files by Extension in All Subfolders
+:: 2024.03.19
+
+
+@echo off
+setlocal enabledelayedexpansion
+
+:: Set the directory to search
+set "search_dir=%~dp0"
+
+:: Temporary file
+set "temp_file=%TEMP%\temp.txt"
+
+:: Get list of files and their sizes in subfolders only
+for /r "%search_dir%" %%F in (*) do (
+    if not "%%~dpF"=="%search_dir%" (
+        echo %%~zF %%~xF >> "%temp_file%"
+    )
+)
+
+:: Initialize the last extension variable
+set "lastext="
+
+:: Process each file extension
+for /f "tokens=1,* delims= " %%A in ('type "%temp_file%" ^| sort /+41') do (
+    set "size=%%A"
+    set "ext=%%B"
+    set "count=1"
+    if not "!lastext!"=="!ext!" (
+        if not "!lastext!"=="" (
+            :: Remove the leading dot from the extension
+            set "lastext=!lastext:~1!"
+            echo !lastext! !count! !totalsize!
+        )
+        set "totalsize=0"
+        set "count=0"
+        set "lastext=!ext!"
+    )
+    set /a totalsize+=size
+    set /a count+=1
+)
+
+:: Write the last extension
+if not "!lastext!"=="" (
+    :: Remove the leading dot from the extension
+    set "lastext=!lastext:~1!"
+    echo !lastext! !count! !totalsize!
+)
+
+:: Clean up
+if exist "%temp_file%" del "%temp_file%"
+
+endlocal

--- a/GithubStatistics/Shell/CalcTotalSizeByExtension.bat
+++ b/GithubStatistics/Shell/CalcTotalSizeByExtension.bat
@@ -1,4 +1,4 @@
-:: Calculate the Total Number and Size of Files by Extension in All Subfolders
+:: Calculate the Total Number and Size of Files by Extension in All Subdirectories
 :: 2024.03.19
 
 
@@ -11,7 +11,7 @@ set "search_dir=%~dp0"
 :: Temporary file
 set "temp_file=%TEMP%\temp.txt"
 
-:: Get list of files and their sizes in subfolders only
+:: Get list of files and their sizes in subdirectories only
 for /r "%search_dir%" %%F in (*) do (
     if not "%%~dpF"=="%search_dir%" (
         echo %%~zF %%~xF >> "%temp_file%"

--- a/GithubStatistics/Shell/CalcTotalSizeByExtension.ps1
+++ b/GithubStatistics/Shell/CalcTotalSizeByExtension.ps1
@@ -1,0 +1,9 @@
+# Calculate the Total Number and Size of Files by Extension in All Subfolders
+# 2024.03.19
+
+Get-ChildItem -Path . -Recurse -File | Where-Object { $_.DirectoryName -ne (Get-Location).Path } | Group-Object Extension | 
+Select-Object @{Name='Extension';Expression={$_.Name -replace '^\.', ''}}, 
+              @{Name='FileCount';Expression={$_.Count}}, 
+              @{Name='TotalSize (Bytes)';Expression={$_.Group | Measure-Object -Property Length -Sum | Select-Object -ExpandProperty Sum}} | 
+Sort-Object 'TotalSize (Bytes)' -Descending | 
+Format-Table -AutoSize

--- a/GithubStatistics/Shell/CalcTotalSizeByExtension.ps1
+++ b/GithubStatistics/Shell/CalcTotalSizeByExtension.ps1
@@ -1,4 +1,4 @@
-# Calculate the Total Number and Size of Files by Extension in All Subfolders
+# Calculate the Total Number and Size of Files by Extension in All Subdirectories
 # 2024.03.19
 
 Get-ChildItem -Path . -Recurse -File | Where-Object { $_.DirectoryName -ne (Get-Location).Path } | Group-Object Extension | 

--- a/GithubStatistics/Shell/CalcTotalSizeByExtension.sh
+++ b/GithubStatistics/Shell/CalcTotalSizeByExtension.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Calculate the Total Number and Size of Files by Extension in All Subfolders
+# 2024.03.19
+
+
+find */ -type f | awk -F'.' '{print $NF}' | sort | uniq -c | while read count ext; do 
+  size=$(find */ -type f -name "*.$ext" -exec du -b {} + | awk '{total+=$1} END {print total}')
+  echo "$ext $count $size"
+done

--- a/GithubStatistics/Shell/CalcTotalSizeByExtension.sh
+++ b/GithubStatistics/Shell/CalcTotalSizeByExtension.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Calculate the Total Number and Size of Files by Extension in All Subfolders
+# Calculate the Total Number and Size of Files by Extension in All Subdirectories
 # 2024.03.19
 
 

--- a/GithubStatistics/Shell/CalcTotalSizeByExtension.vbs
+++ b/GithubStatistics/Shell/CalcTotalSizeByExtension.vbs
@@ -1,0 +1,40 @@
+' Calculate the Total Number and Size of Files by Extension in All Subfolders
+' 2024.03.19
+
+' Run in Console
+' > cscript ./CalcTotalSizeByExtension.vbs
+
+
+Set dict = CreateObject("Scripting.Dictionary")
+
+Set fso = CreateObject("Scripting.FileSystemObject")
+Set folder = fso.GetFolder(".")
+Set subFolders = CreateObject("Scripting.Dictionary")
+
+' Skip the current folder by starting with its subfolders
+For Each subfolder in folder.SubFolders
+    subFolders.Add subfolder.Path, subfolder
+Next
+
+Do While subFolders.Count > 0
+    Set folder = subFolders.Item(subFolders.Keys()(0))
+    subFolders.Remove folder.Path
+    For Each subfolder in folder.SubFolders
+        subFolders.Add subfolder.Path, subfolder
+    Next
+    For Each file In folder.Files
+        ext = fso.GetExtensionName(file)
+        If Not dict.Exists(ext) Then
+            dict.Add ext, Array(0,0)
+        End If
+        fileInfo = dict(ext)
+        fileInfo(0) = fileInfo(0) + 1
+        fileInfo(1) = fileInfo(1) + file.Size
+        dict(ext) = fileInfo
+    Next
+Loop
+
+' Output results to the console
+For Each ext In dict.Keys
+    WScript.StdOut.WriteLine ext & " " & dict(ext)(0) & " " & dict(ext)(1)
+Next

--- a/GithubStatistics/Shell/CalcTotalSizeByExtension.vbs
+++ b/GithubStatistics/Shell/CalcTotalSizeByExtension.vbs
@@ -1,4 +1,4 @@
-' Calculate the Total Number and Size of Files by Extension in All Subfolders
+' Calculate the Total Number and Size of Files by Extension in All Subdirectories
 ' 2024.03.19
 
 ' Run in Console

--- a/GithubStatistics/Shell/Test_Subdirectory/Test_BTS.ini
+++ b/GithubStatistics/Shell/Test_Subdirectory/Test_BTS.ini
@@ -1,0 +1,14 @@
+[Leader]
+Name = RM
+
+[Vocalist]
+Name = Jin
+Name = Jimin
+Name = V
+Name = Jungkook
+
+[Rapper]
+Name = Suga
+
+[Dancer]
+Name = J-Hope

--- a/GithubStatistics/Shell/Test_Subdirectory/Test_BTS.ini
+++ b/GithubStatistics/Shell/Test_Subdirectory/Test_BTS.ini
@@ -1,14 +1,25 @@
-[Leader]
-Name = RM
+[RM]
+Position = Leader
+Position = MainRapper
 
-[Vocalist]
-Name = Jin
-Name = Jimin
-Name = V
-Name = Jungkook
+[Jin]
+Position = SubVocalist
 
-[Rapper]
-Name = Suga
+[Suga]
+Position = LeadRapper
 
-[Dancer]
-Name = J-Hope
+[J-Hope]
+Position = MainDancer
+Position = SubRapper
+
+[Jimin]
+Position = MainDancer
+Position = LeadVocalist
+
+[V]
+Position = SubVocalist
+
+[Jungkook]
+Position = MainVocalist
+Position = LeadDancer
+Position = SubRapper

--- a/GithubStatistics/Shell/Test_Subdirectory/Test_BlackPink.json
+++ b/GithubStatistics/Shell/Test_Subdirectory/Test_BlackPink.json
@@ -1,0 +1,8 @@
+{
+    "members": [
+        "Jisoo",
+        "Jennie",
+        "Rosé",
+        "Lisa"
+    ]
+}

--- a/GithubStatistics/Shell/Test_Subdirectory/Test_SkidRow.txt
+++ b/GithubStatistics/Shell/Test_Subdirectory/Test_SkidRow.txt
@@ -1,0 +1,1 @@
+Live for your smile and die for your kiss

--- a/GithubStatistics/Shell/Test_Subdirectory/Test_Subdirectory/Test_GunsNRoses.txt
+++ b/GithubStatistics/Shell/Test_Subdirectory/Test_Subdirectory/Test_GunsNRoses.txt
@@ -1,0 +1,1 @@
+Don't you cry tonight I still love you babe

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ### \<List>
 
-- [※ Github Statistics](#※-github-statistics)
+- [※ Github Statistics](#-github-statistics)
 - [VBA](#vba)
 - [Python](#python)
 - [Shell](#shell)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 ## [※ Github Statistics](#list)
 
-  - [Shell : Calculate the Total Number and Size of Files by Extension in All Subfolders (2024.03.19)](/GithubStatistics/README.md#shell--calculate-the-total-number-and-size-of-files-by-extension-in-all-subfolders-20240319)
+  - [Shell : Calculate the Total Number and Size of Files by Extension in All Subdirectories (2024.03.19)](/GithubStatistics/README.md#shell--calculate-the-total-number-and-size-of-files-by-extension-in-all-subdirectories-20240319)
   - [Python : Get Daily Contribution Data by Crawling (2023.12.31)](/GithubStatistics/README.md#python--get-daily-contribution-data-by-crawling-20231231)
   - [TypeScript : List a User's Repositories (2023.10.26)](/GithubStatistics/README.md#typescript--list-a-users-repositories-20231026)
   - [Google Sheet : Most Used Languages (2023.10.25)](/GithubStatistics/README.md#google-sheet--most-used-languages-20231025)

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 
 ## [※ Github Statistics](#list)
 
+  - [Shell : Calculate the Total Number and Size of Files by Extension in All Subfolders (2024.03.19)](/GithubStatistics/README.md#shell--calculate-the-total-number-and-size-of-files-by-extension-in-all-subfolders-20240319)
   - [Python : Get Daily Contribution Data by Crawling (2023.12.31)](/GithubStatistics/README.md#python--get-daily-contribution-data-by-crawling-20231231)
   - [TypeScript : List a User's Repositories (2023.10.26)](/GithubStatistics/README.md#typescript--list-a-users-repositories-20231026)
   - [Google Sheet : Most Used Languages (2023.10.25)](/GithubStatistics/README.md#google-sheet--most-used-languages-20231025)


### PR DESCRIPTION
## Output

- Bash
  ```bash
  ini 1 140
  json 1 102
  txt 2 88
  ```

- Batchfile
  ```bat
  json  1 102
  ini  1 140
  txt  2 88
  ```

- VBScript
  ```vbs
  Microsoft (R) Windows Script Host 버전 5.812
  Copyright (C) Microsoft Corporation. All rights reserved.

  json 1 102
  ini 1 140
  txt 2 88
  ```

- PowerShell
  ```ps1
  Extension FileCount TotalSize (Bytes)
  --------- --------- -----------------
  ini               1               140
  json              1               102
  txt               2                88
  ```


## Future Improvements

- Calculate the summation
- Sort by the total size